### PR TITLE
simplification and fixes

### DIFF
--- a/coupling.scad
+++ b/coupling.scad
@@ -8,30 +8,33 @@
 // http://www.reprap.org/wiki/Prusa_Mendel
 // http://github.com/prusajr/PrusaMendel
 
-difference(){
+difference() {
+	union() {
+		cylinder(h = 30, r=7);
+		translate(v = [0, 6, 15])
+			cube(size = [14,12,30], center = true);
+	}
 
-union(){
-cylinder(h = 30, r=7);
-translate(v = [0, 6, 15]) cube(size = [14,12,30], center = true);
+	// inside diameter
+	translate(v = [0, 0, -1])
+		cylinder(h = 16, r=4.3, $fn=16);
+	translate(v = [0, 0, 14.5])
+		cylinder(h = 16, r=2.9, $fn=16);
+
+	// screw holes
+	translate(v = [-15, 7, 7.5])
+		rotate ([0,90,0])
+			cylinder(h = 30, r=2.7, $fn=16);
+	translate(v = [-15, 7, 22.5])
+		rotate ([0,90,0])
+			cylinder(h = 30, r=2.7, $fn=16);
+				
+				
+	//main cut
+	translate(v = [0, 10, 14])
+		cube(size = [2,20,35], center = true);
+
+	//difference cut
+	translate(v = [0, 7, 15])
+		cube(size = [20,8,1], center = true);
 }
-
-// inside diameter
-translate(v = [0, 0, -1])cylinder(h = 16, r=4.3, $fn=16);
-translate(v = [0, 0, 14.5])cylinder(h = 16, r=2.9, $fn=16);
-
-// screw holes
-rotate ([0,0,90]) translate(v = [7, 15, 7.5]) rotate ([90,0,0]) cylinder(h = 30, r=2.7, $fn=16);
-rotate ([0,0,90]) translate(v = [7, 15, 22.5]) rotate ([90,0,0]) cylinder(h = 30, r=2.7, $fn=16);
-
-//main cut
-translate(v = [0, 10, 14]) cube(size = [2,20,35], center = true);
-
-//difference cut
-translate(v = [0, 7, 15])  cube(size = [20,8,1], center = true);
-}
-
-
-// not important
-% cylinder(h = 30, r=2.9, $fn=16);
-% rotate ([0,0,90]) translate(v = [7, 15, 7.5]) rotate ([90,0,0]) cylinder(h = 30, r=2.7, $fn=16);
-% rotate ([0,0,90]) translate(v = [7, 15, 22.5]) rotate ([90,0,0]) cylinder(h = 30, r=2.7, $fn=16);

--- a/x-carriage.scad
+++ b/x-carriage.scad
@@ -19,79 +19,139 @@ include <configuration.scad>
 // false - vertical
 	orientation = true;
 
-translate(v = [0,0,2.5]) union(){difference(){
-	union(){
-		//Base block
-			cube(size = [70,70,5], center = true);
-		//Nut holder base - extruder
-			if(orientation) translate(v = [0, 0, 1]) cube(size = [12,70,7], center = true);
-			if(orientation == false) translate(v = [0, 0, 1]) cube(size = [70,12,7], center = true);
+translate(v = [0,0,2.5]) {
+	union() {
+		difference() {
+			union() {
+				//Base block
+				cube(size = [70,70,5], center = true);
 
-		//Nut holder base - belt clamps
-		translate(v = [33, -18, 1]) cube(size = [45,15,7], center = true);
-		translate(v = [33, 18, 1]) cube(size = [45,15,7], center = true);
+				//Nut holder base - extruder
+				if(orientation)
+					translate(v = [0, 0, 1])
+						cube(size = [12,70,7], center = true);
+				if(orientation == false)
+					translate(v = [0, 0, 1])
+						cube(size = [70,12,7], center = true);
 
-		//Bushing holder
-		translate(v = [-25, 30, 5])cube(size = [26,10,15], center = true);
-		translate(v = [-25, -30, 5])cube(size = [26,10,15], center = true);
-		translate(v = [25, -30, 5])cube(size = [26,10,15], center = true);
-		translate(v = [25, 30, 5])cube(size = [26,10,15], center = true);
-		
-		// fan holder
-		translate(v = [-25, 20, 2])  cube(size = [20,10,9], center = true);
-		translate(v = [-25, -20, 2]) cube(size = [20,10,9], center = true);
+				//Nut holder base - belt clamps
+				translate(v = [33, -18, 1])
+					cube(size = [45,15,7], center = true);
+				translate(v = [33, 18, 1])
+					cube(size = [45,15,7], center = true);
 
+				//Bushing holder
+				translate(v = [-25, 30, 5])
+					cube(size = [26,10,15], center = true);
+				translate(v = [-25, -30, 5])
+					cube(size = [26,10,15], center = true);
+				translate(v = [25, -30, 5])
+					cube(size = [26,10,15], center = true);
+				translate(v = [25, 30, 5])
+					cube(size = [26,10,15], center = true);
+
+				// fan holder
+				translate(v = [-25, 20, 2])
+					cube(size = [20,10,9], center = true);
+				translate(v = [-25, -20, 2])
+					cube(size = [20,10,9], center = true);
+			}
+			
+			//main cutout
+			if(orientation)
+				translate(v = [0, -5, 2])
+					cube(size = [30,30,20], center = true);
+			if(orientation == false)
+				cube(size = [30,50,20], center = true);
+			translate(v = [-12.5,0,0])
+				cube(size = [5,50,20], center = true);
+
+			// bushing cutouts
+			translate(v = [25, 30.4, 7.5])
+				cube(size = [18,11,9], center = true);
+			translate(v = [-25, 30.4, 7.5])
+				cube(size = [18,11,9], center = true);
+			translate(v = [25, -30.4, 7.5])
+				cube(size = [18,11,9], center = true);
+			translate(v = [-25, -30.4, 7.5])
+				cube(size = [18,11,9], center = true);
+
+			// bushing clamps
+			translate(v = [25, 30.4, 12])
+				rotate(a=[90,0,0])
+					cylinder(h = 11, r=9, $fn=12, center=true);
+			translate(v = [-25, 30.4, 12])
+				rotate(a=[90,0,0])
+					cylinder(h = 11, r=9, $fn=12, center=true);
+			translate(v = [25, -30.4, 12])
+				rotate(a=[90,0,0])
+					cylinder(h = 11, r=9, $fn=12, center=true);
+			translate(v = [-25, -30.4, 12])
+				rotate(a=[90,0,0])
+					cylinder(h = 11, r=9, $fn=12, center=true);
+
+			// holes for connecting extruder
+			if(orientation) {
+				// screw holes
+				translate(v = [0, -30, 12])
+					cylinder(h = 80, r=m4_diameter/2, $fn=9, center=true);
+				translate(v = [0, 20, 12])
+					cylinder(h = 80, r=m4_diameter/2, $fn=9, center=true);
+				// nut traps
+				translate(v = [0, -30, 5])
+					cylinder(h = 9, r=m4_nut_diameter/2, $fn=6, center=true);
+				translate(v = [0, 20, 5])
+					cylinder(h = 9, r=m4_nut_diameter/2, $fn=6, center=true);
+			}
+
+			if(orientation == false) {
+				// screw holes
+				translate(v = [-25, 0, 12])
+					cylinder(h = 80, r=m4_diameter/2, $fn=9, center=true);
+				translate(v = [25, 0, 12])
+					cylinder(h = 80, r=m4_diameter/2, $fn=9, center=true);
+				// nut traps
+				translate(v = [-25, 0, 5])
+					cylinder(h = 9, r=m4_nut_diameter/2, $fn=6, center=true);
+				translate(v = [25, 0, 5])
+					cylinder(h = 9, r=m4_nut_diameter/2, $fn=6, center=true);
+			}
+
+			// belt clamp screw holes
+			translate(v = [30, -18, 12])
+				cylinder(h = 80, r=m4_diameter/2, $fn=9, center=true);
+			translate(v = [48, -18, 12])
+				cylinder(h = 80, r=m4_diameter/2, $fn=9, center=true);
+			translate(v = [30, 18, 12])
+				cylinder(h = 80, r=m4_diameter/2, $fn=9, center=true);
+			translate(v = [48, 18, 12])
+				cylinder(h = 80, r=m4_diameter/2, $fn=9, center=true);
+
+			// belt clamp nut traps
+			translate(v = [48, -18, 5])
+				cylinder(h = 9, r=m4_nut_diameter/2, $fn=6, center=true);
+			translate(v = [30, -18, 5])
+				cylinder(h = 9, r=m4_nut_diameter/2, $fn=6, center=true);
+			translate(v = [30, 18, 5])
+				cylinder(h = 9, r=m4_nut_diameter/2, $fn=6, center=true);
+			translate(v = [48, 18, 5])
+				cylinder(h = 9, r=m4_nut_diameter/2, $fn=6, center=true);
+
+			// fan mount screw holes
+			translate(v = [-25, -20, 2.5])
+				rotate(a=[0,90,0])
+					cylinder(h = 30, r=m4_diameter/2, $fn=10, center=true);
+			translate(v = [-25, 20, 2.5])
+				rotate(a=[0,90,0])
+					cylinder(h = 30, r=m4_diameter/2, $fn=10, center=true);
+
+			if(bfb) {
+				if(orientation == false)
+					cylinder(h = 40, r=21, $fn=20, center=true);
+				if(orientation)
+					translate(v = [0, -5, 0])
+						cylinder(h = 40, r=21, $fn=20, center=true);
+			}
+		}
 	}
-	//main cutout
-	if(orientation) translate(v = [0, -5, 2]) cube(size = [30,30,20], center = true);
-	if(orientation == false) cube(size = [30,50,20], center = true);
-	translate(v = [-12.5,0,0]) cube(size = [5,50,20], center = true);
-
-	translate(v = [25, 30.4, 12]) rotate(a=[90,0,0]) cylinder(h = 11, r=18/2, $fn=12, center=true);
-	translate(v = [25, 30.4, 7.5])cube(size = [18,11,9], center = true);
-	translate(v = [-25, 30.4, 12]) rotate(a=[90,0,0]) cylinder(h = 11, r=18/2, $fn=12, center=true);
-	translate(v = [-25, 30.4, 7.5])cube(size = [18,11,9], center = true);
-	translate(v = [25, -30.4, 12]) rotate(a=[90,0,0]) cylinder(h = 11, r=18/2, $fn=12, center=true);
-	translate(v = [25, -30.4, 7.5])cube(size = [18,11,9], center = true);
-	translate(v = [-25, -30.4, 12]) rotate(a=[90,0,0]) cylinder(h = 11, r=18/2, $fn=12, center=true);
-	translate(v = [-25, -30.4, 7.5])cube(size = [18,11,9], center = true);
-
-	// holes for connecting extruder
-		if(orientation) translate(v = [0, 0, 0]) {
-		translate(v = [0, -30, 12]) cylinder(h = 80, r=m4_diameter/2, $fn=9, center=true);
-		translate(v = [0, -30, 5]) cylinder(h = 9, r=m4_nut_diameter/2, $fn=6, center=true);
-		translate(v = [0, 20, ]) cylinder(h = 20, r=m4_diameter/2, $fn=9, center=true);
-		translate(v = [0, 20, 5]) cylinder(h = 9, r=4.5, $fn=6, center=true);
-		}
-	
-		if(orientation == false) {
-		translate(v = [-25, 0, 12]) cylinder(h = 80, r=m4_diameter/2, $fn=9, center=true);
-		translate(v = [-25, 0, 5]) cylinder(h = 9, r=m4_nut_diameter/2, $fn=6, center=true);
-		translate(v = [25, 0, ]) cylinder(h = 20, r=m4_diameter/2, $fn=9, center=true);
-		translate(v = [25, 0, 5]) cylinder(h = 9, r=4.5, $fn=6, center=true);
-		}
-
-	translate(v = [30, -18, 12]) cylinder(h = 80, r=m4_diameter/2, $fn=9, center=true);
-	translate(v = [30, -18, 5]) cylinder(h = 9, r=m4_nut_diameter/2, $fn=6, center=true);
-	translate(v = [48, -18, 12]) cylinder(h = 80, r=m4_diameter/2, $fn=9, center=true);
-	translate(v = [48, -18, 5]) cylinder(h = 9, r=m4_nut_diameter/2, $fn=6, center=true);
-
-	translate(v = [30, 18, 12]) cylinder(h = 80, r=m4_diameter/2, $fn=9, center=true);
-	translate(v = [30, 18, 5]) cylinder(h = 9, r=m4_nut_diameter/2, $fn=6, center=true);
-	translate(v = [48, 18, 12]) cylinder(h = 80, r=m4_diameter/2, $fn=9, center=true);
-	translate(v = [48, 18, 5]) cylinder(h = 9, r=m4_nut_diameter/2, $fn=6, center=true);
-
-
-		translate(v = [-25, -20, 2.5]) rotate(a=[0,90,0]) cylinder(h = 30, r=m4_diameter/2, $fn=10, center=true);
-
-		translate(v = [-25, 20, 2.5]) rotate(a=[0,90,0]) cylinder(h = 30, r=m4_diameter/2, $fn=10, center=true);
-
-if(bfb) if(orientation == false) cylinder(h = 40, r=21, $fn=20, center=true);
-if(bfb) if(orientation) translate(v = [0, -5, 0]) cylinder(h = 40, r=21, $fn=20, center=true);
-}//
-%translate(v = [-45, -25, -2.5]) cube(size=[10,50,50]);
-//translate(v = [10, -25, 9]) %cube(size=[50,50,14]);
 }
-
-
-

--- a/x-end-idler.scad
+++ b/x-end-idler.scad
@@ -9,82 +9,96 @@
 
 include <configuration.scad>
 
-translate(v = [0,35,24.5]) union(){ 
+translate(v = [0,35,24.5]) {
+	union() {
+		difference() {
+			union() {
+				translate(v = [-25, -40, -16.6])
+					cube(size = [20,40,15.8], center = true);
+				translate(v = [25, -40, -16.6])
+					cube(size = [20,40,15.8], center = true);
+			}
 
-difference(){
-union(){
-//translate(v = [0, -25, 0]) cube(size = [70,70,5], center = true);
-translate(v = [0, -25, 0])translate(v = [-25, 0, -16.6])cube(size = [20,70,15.8], center = true);
-translate(v = [0, -25, 0])translate(v = [25, 0, -16.6])cube(size = [20,70,15.8], center = true);
-}
-translate(v = [0, 0, -15])cube(size = [80,40,50], center = true);
+			//nut traps
+			translate(v = [-25, -29, -19.7])
+				cylinder(h = 7, r=m3_nut_diameter/2, $fn=6, center=true);
+			translate(v = [-25, -29, -20])
+				cylinder(h = 10, r=m3_diameter/2, $fn=9, center=true);
+			translate(v = [25, -29, -19.7])
+				cylinder(h = 7, r=m3_nut_diameter/2, $fn=6, center=true);
+			translate(v = [25, -29, -20])
+				cylinder(h = 10, r=m3_diameter/2, $fn=9, center=true);
 
-//nut traps
+			translate(v = [-25, -50, -19.7])
+				cylinder(h = 7, r=m3_nut_diameter/2, $fn=6, center=true);
+			translate(v = [-25, -50, -20])
+				cylinder(h = 10, r=m3_diameter/2, $fn=9, center=true);
+			translate(v = [25, -50, -19.7])
+				cylinder(h = 7, r=m3_nut_diameter/2, $fn=6, center=true);
+			translate(v = [25, -50, -20])
+				cylinder(h = 10, r=m3_diameter/2, $fn=9, center=true);
 
-translate(v = [-25, -29, -19.7]) cylinder(h = 7, r=m3_nut_diameter/2, $fn=6, center=true);
-translate(v = [-25, -29, -20]) cylinder(h = 10, r=m3_diameter/2, $fn=9, center=true);
-translate(v = [25, -29, -19.7]) cylinder(h = 7, r=m3_nut_diameter/2, $fn=6, center=true);
-translate(v = [25, -29, -20]) cylinder(h = 10, r=m3_diameter/2, $fn=9, center=true);
+			//holes for axis
+			translate(v = [-25, -18, -16.7])
+				rotate(a=[90,0,0]) {
+					cylinder(h = 120, r=4.5, $fn=20, center=true);
+					translate(v = [0, 2.60, 0])
+						cylinder(h = 120, r=3.65, $fn=6, center=true);
+				}
+			translate(v = [25, -18, -16.7])
+				rotate(a=[90,0,0]) {
+					cylinder(h = 120, r=4.5, $fn=20, center=true);
+					translate(v = [0, 2.60, 0])
+						cylinder(h = 120, r=3.65, $fn=6, center=true);
+				}
+		}
 
-translate(v = [-25, -50, -19.7]) cylinder(h = 7, r=m3_nut_diameter/2, $fn=6, center=true);
-translate(v = [-25, -50, -20]) cylinder(h = 10, r=m3_diameter/2, $fn=9, center=true);
-translate(v = [25, -50, -19.7]) cylinder(h = 7, r=m3_nut_diameter/2, $fn=6, center=true);
-translate(v = [25, -50, -20]) cylinder(h = 10, r=m3_diameter/2, $fn=9, center=true);
+		//slider
+		translate(v = [0, -25, 15])
+			difference() {
+				union() {
+					translate(v = [0, -3.5, -7])
+						cube(size = [24,17,65], center = true);
+					translate(v = [0, -3.5, -31.65])
+						cube(size = [35,17,15.8], center = true);
+				}
+				translate(v = [0, -0, -7])
+					cube(size = [17,17,70], center = true);
+			}
 
-//holes for axis
-translate(v = [-25, -18, -16.7]) rotate(a=[90,0,0]) {
-	cylinder(h = 120, r=4.5, $fn=20, center=true);
-	translate(v = [0, 2.60, 0]) rotate(a=[0,0,0]) cylinder(h = 120, r=3.65, $fn=6, center=true);
-}
-translate(v = [25, -18, -16.7]) rotate(a=[90,0,0]) {
-	cylinder(h = 120, r=4.5, $fn=20, center=true);
-	translate(v = [0, 2.60, 0]) rotate(a=[0,0,0]) cylinder(h = 120, r=3.65, $fn=6, center=true);
-}
-//slider cutouts
-translate(v = [0, -25, 15]) 
-	difference(){
-	translate(v = [0, -0, -14.5])cube(size = [23,23,50], center = true);
+		//nut trap
+		translate(v = [0, -55, 15]) {
+			difference() {
+				union() {
+					translate(v = [0, -0, -19.5])
+						cylinder(h = 40, r=12, $fn=6, center=true);
+					translate(v = [0, 0, -31.65])
+						cube(size = [35,10,15.8], center = true);
+				}
+				translate(v = [0, 0, 16])
+					cylinder(h = 90, r=m8_nut_diameter/2, $fn=6, center=true);
+				translate(v = [0, 0, -78])
+					cylinder(h = 90, r=m8_nut_diameter/2, $fn=6, center=true);
+				translate(v = [0, 0, 0])
+					cylinder(h = 100, r=m8_diameter/2, $fn=9, center=true);
+			}
+		}
+
+		//idler wheel connector
+		mirror() {
+			translate(v = [0, -35, -12]) {
+				translate(v = [21, -23.5, 26.3])
+					cube(size = [24,3,2.4], center = true);
+				translate(v = [21, 13.5, 26.3])
+					cube(size = [24,3,2.4], center = true);
+				difference() {
+					translate(v = [33.5, -5, 12.5])
+						cube(size = [3,40,30], center = true);
+					translate(v = [32.5, -6, 20.3])
+						rotate(a=[0,90,0])
+							cylinder(h = 90, r=m4_diameter/2, $fn=9, center=true);
+				}
+			}
+		}
 	}
-//nut trap
-translate(v = [0, -55, 15]) {
-	difference(){
-	translate(v = [0, -0, -15])cylinder(h = 50, r=12, $fn=6, center=true);
-	}
 }
-}
-
-//slider
-translate(v = [0, -25, 15]) 
-	difference(){
-union(){
-	translate(v = [0, -3.5, -7])cube(size = [24,17,65], center = true);
-
-	translate(v = [0, -3.5, -31.65]) cube(size = [35,17,15.8], center = true);}
-	translate(v = [0, -0, -7])cube(size = [17,17,70], center = true);}
-
-//nut trap
-translate(v = [0, -55, 15]) {
-difference(){
-	union(){difference(){
-union(){
-	translate(v = [0, -0, -19.5])cylinder(h = 40, r=12, $fn=6, center=true);
-	translate(v = [0, 0, -31.65]) cube(size = [35,10,15.8], center = true);}
-	cylinder(h = 90, r=m8_nut_diameter/2, $fn=6, center=true);
-	}
-	translate(v = [0, 0, -31]) cylinder(h = 4, r=11, $fn=6, center=true);}
-	translate(v = [0, 0, 12.5]) cylinder(h = 90, r=m8_diameter/2, $fn=9, center=true);
-}
-}
-
-
-//idler wheel connector
-mirror(){
-translate(v = [0, -35, -12]) difference(){
-union(){
-translate(v = [21, -23.5, 26.3]) cube(size = [24,3,2.4], center = true);
-translate(v = [21, 13.5, 26.3]) cube(size = [24,3,2.4], center = true);
-translate(v = [33.5, -5, 12.5]) cube(size = [3,40,30], center = true);
-}
-
-translate(v = [32.5, -6, 28-3-4.7]) rotate(a=[0,90,0]) cylinder(h = 90, r=m4_diameter/2, $fn=9, center=true);}
-}}

--- a/x-end-motor.scad
+++ b/x-end-motor.scad
@@ -9,86 +9,94 @@
 
 include <configuration.scad>
 
-translate(v = [0,17,24.5]) union(){
-difference(){
-union(){
-//translate(v = [0, -25, 0]) cube(size = [70,70,5], center = true);
-translate(v = [0, -25, 0])translate(v = [-25, 0, -16.6])cube(size = [20,70,15.8], center = true);
-translate(v = [0, -25, 0])translate(v = [25, 0, -16.6])cube(size = [20,70,15.8], center = true);
-}
-translate(v = [0, 0, -15])cube(size = [80,40,50], center = true);
+translate(v = [0,17,24.5]) {
+	union() {
+		difference(){
+			union(){
+				translate(v = [-25, -25, -16.6])
+					cube(size = [20,70,15.8], center = true);
+				translate(v = [25, -25, -16.6])
+					cube(size = [20,70,15.8], center = true);
+			}
 
-//nut traps
+			translate(v = [0, 0, -15])
+				cube(size = [80,40,50], center = true);
 
-translate(v = [-25, -29, -19.7]) cylinder(h = 7, r=m3_nut_diameter/2, $fn=6, center=true);
-translate(v = [-25, -29, -20]) cylinder(h = 10, r=m3_diameter/2, $fn=9, center=true);
-translate(v = [25, -29, -19.7]) cylinder(h = 7, r=m3_nut_diameter/2, $fn=6, center=true);
-translate(v = [25, -29, -20]) cylinder(h = 10, r=m3_diameter/2, $fn=9, center=true);
+			//nut traps
+			translate(v = [-25, -29, -19.7]) cylinder(h = 7, r=m3_nut_diameter/2, $fn=6, center=true);
+			translate(v = [-25, -29, -20]) cylinder(h = 10, r=m3_diameter/2, $fn=9, center=true);
+			translate(v = [25, -29, -19.7]) cylinder(h = 7, r=m3_nut_diameter/2, $fn=6, center=true);
+			translate(v = [25, -29, -20]) cylinder(h = 10, r=m3_diameter/2, $fn=9, center=true);
 
-translate(v = [-25, -50, -19.7]) cylinder(h = 7, r=m3_nut_diameter/2, $fn=6, center=true);
-translate(v = [-25, -50, -20]) cylinder(h = 10, r=m3_diameter/2, $fn=9, center=true);
-translate(v = [25, -50, -19.7]) cylinder(h = 7, r=m3_nut_diameter/2, $fn=6, center=true);
-translate(v = [25, -50, -20]) cylinder(h = 10, r=m3_diameter/2, $fn=9, center=true);
+			translate(v = [-25, -50, -19.7]) cylinder(h = 7, r=m3_nut_diameter/2, $fn=6, center=true);
+			translate(v = [-25, -50, -20]) cylinder(h = 10, r=m3_diameter/2, $fn=9, center=true);
+			translate(v = [25, -50, -19.7]) cylinder(h = 7, r=m3_nut_diameter/2, $fn=6, center=true);
+			translate(v = [25, -50, -20]) cylinder(h = 10, r=m3_diameter/2, $fn=9, center=true);
 
-//holes for axis
-translate(v = [-25, -18, -16.7]) rotate(a=[90,0,0]) {
-	cylinder(h = 120, r=4.5, $fn=20, center=true);
-	translate(v = [0, 2.60, 0]) rotate(a=[0,0,0]) cylinder(h = 120, r=3.65, $fn=6, center=true);
-}
-translate(v = [25, -18, -16.7]) rotate(a=[90,0,0]) {
-	cylinder(h = 120, r=4.5, $fn=20, center=true);
-	translate(v = [0, 2.60, 0]) rotate(a=[0,0,0]) cylinder(h = 120, r=3.65, $fn=6, center=true);
-}
-//slider cutouts
-translate(v = [0, -25, 15]) 
-	difference(){
-	translate(v = [0, -0, -14.5])cube(size = [23,23,50], center = true);
+			//holes for axis
+			translate(v = [-25, -18, -16.7])
+				rotate(a=[90,0,0]) {
+					cylinder(h = 120, r=4.5, $fn=20, center=true);
+					translate(v = [0, 2.60, 0])
+						cylinder(h = 120, r=3.65, $fn=6, center=true);
+				}
+			translate(v = [25, -18, -16.7])
+				rotate(a=[90,0,0]) {
+					cylinder(h = 120, r=4.5, $fn=20, center=true);
+					translate(v = [0, 2.60, 0])
+						cylinder(h = 120, r=3.65, $fn=6, center=true);
+				}
+		}
+
+		//slider
+		translate(v = [0, -25, 15]) {
+			difference(){
+				union(){
+					translate(v = [0, -3.5, -7])cube(size = [24,17,65], center = true);
+					translate(v = [0, -3.5, -31.65]) cube(size = [35,17,15.8], center = true);
+				}
+				translate(v = [0, -0, -7])cube(size = [17,17,70], center = true);
+			}
+		}
+
+		//nut trap
+		translate(v = [0, -55, 15]) {
+			difference() {
+				union() {
+					translate(v = [0, -0, -19.5])
+						cylinder(h = 40, r=12, $fn=6, center=true);
+					translate(v = [0, 0, -31.65])
+						cube(size = [35,10,15.8], center = true);
+				}
+				translate(v = [0, 0, 16])
+					cylinder(h = 90, r=m8_nut_diameter/2, $fn=6, center=true);
+				translate(v = [0, 0, -78])
+					cylinder(h = 90, r=m8_nut_diameter/2, $fn=6, center=true);
+				translate(v = [0, 0, 0])
+					cylinder(h = 100, r=m8_diameter/2, $fn=9, center=true);
+			}
+		}
+
+		//nema17 connector
+		translate(v = [0, 0, -12]) {
+			difference(){
+				union(){
+					translate(v = [21, -22.5, 36.5]) cube(size = [24,5,6], center = true);
+					translate(v = [32.5, 2, 13.5]) cube(size = [5,54,52], center = true);
+					translate(v = [22.5, 2, -11]) cube(size = [20,54,3], center = true);
+				}
+
+				translate(v = [32.5, 7, 18.8]) {
+					translate(v = [7, 0, 0])
+						rotate(a=[0,90,0])
+							cylinder(h = 80, r=12, $fn=20, center=true);
+
+					translate(v = [0, 15.5, 12.5]) cube(size = [20,3.5,8], center = true);
+					translate(v = [0, -15.5, 12.5]) cube(size = [20,3.5,8], center = true);
+					translate(v = [0, 15.5, -12.5]) cube(size = [20,3.5,8], center = true);
+					translate(v = [0, -15.5, -12.5]) cube(size = [20,3.5,8], center = true);
+				}
+			}
+		}
 	}
-//nut trap
-translate(v = [0, -55, 15]) {
-	difference(){
-	translate(v = [0, -0, -15])cylinder(h = 50, r=12, $fn=6, center=true);
-	}
 }
-}
-
-//slider
-translate(v = [0, -25, 15]) 
-	difference(){
-union(){
-	translate(v = [0, -3.5, -7])cube(size = [24,17,65], center = true);
-
-	translate(v = [0, -3.5, -31.65]) cube(size = [35,17,15.8], center = true);}
-	translate(v = [0, -0, -7])cube(size = [17,17,70], center = true);}
-
-//nut trap
-translate(v = [0, -55, 15]) {
-difference(){
-	union(){difference(){
-union(){
-	translate(v = [0, -0, -19.5])cylinder(h = 40, r=12, $fn=6, center=true);
-	translate(v = [0, 0, -31.65]) cube(size = [35,10,15.8], center = true);}
-	cylinder(h = 90, r=m8_nut_diameter/2, $fn=6, center=true);
-	}
-	translate(v = [0, 0, -31]) cylinder(h = 4, r=11, $fn=6, center=true);}
-	translate(v = [0, 0, 12.5]) cylinder(h = 90, r=m8_diameter/2, $fn=9, center=true);
-}
-}
-
-
-//nema17 connector
-translate(v = [0, 0, -12]) difference(){
-union(){
-translate(v = [21, -22.5, 36.5]) cube(size = [24,5,6], center = true);
-translate(v = [32.5, 2, 13.5]) cube(size = [5,54,52], center = true);
-translate(v = [22.5, 2, -11]) cube(size = [20,54,3], center = true);}
-
-translate(v = [0, 0, -4.7]){
-	translate(v = [32.5, 7, 23.5]) rotate(a=[0,90,0]) rotate(a=[0,0,30]) cylinder(h = 80, r=12, $fn=20, center=true);
-
-	translate(v = [32.5, 7+15.5, 23.5+15.5-3]) cube(size = [20,3.5,8], center = true);
-	translate(v = [32.5, 7-15.5, 23.5+15.5-3]) cube(size = [20,3.5,8], center = true);
-	translate(v = [32.5, 7+15.5, 23.5-15.5+3]) cube(size = [20,3.5,8], center = true);
-	translate(v = [32.5, 7-15.5, 23.5-15.5+3]) cube(size = [20,3.5,8], center = true);
-}
-}}

--- a/z-motor-mount.scad
+++ b/z-motor-mount.scad
@@ -8,27 +8,64 @@
 // http://www.reprap.org/wiki/Prusa_Mendel
 // http://github.com/prusajr/PrusaMendel
 
-difference(){
-union(){
-translate(v=[2.5,0,0]) cube(size = [55,60,16], center = true);
-translate(v=[2.5,0,-4]) cube(size = [55,76,8], center = true);
-translate(v=[-25,30,0]) rotate(a=[0,90,0]) cylinder(h = 55, r=8, $fn=30);
-translate(v=[-25,-30,0]) rotate(a=[0,90,0]) cylinder(h = 55, r=8, $fn=30);
-}
-translate(v=[-2.1,0,3.1]) cube(size = [46,43,10], center = true);
-translate(v=[15,15,0]) cube(size = [9,3.2,25], center = true);
-translate(v=[-15,15,0]) cube(size = [9,3.2,25], center = true);
-translate(v=[15,-15,0]) cube(size = [9,3.2,25], center = true);
-translate(v=[-15,-15,0]) cube(size = [9,3.2,25], center = true);
-translate(v=[0,0,-20])cylinder(h = 100, r=15);
-translate(v=[30,0,-20]) cylinder(h = 100, r=4.2);
-translate(v=[-50,30,0]) rotate(a=[0,90,0]) cylinder(h = 100, r=4.5);
-translate(v=[-50,-30,0]) rotate(a=[0,90,0]) cylinder(h = 100, r=4.5);
+difference() {
+	// body
+	union() {
+		translate(v=[2.5,0,0])
+			cube(size = [55,60,16], center = true);
+		translate(v=[2.5,0,-4])
+			cube(size = [55,76,8], center = true);
+		translate(v=[-25,30,0])
+			rotate(a=[0,90,0])
+				cylinder(h = 55, r=8, $fn=30);
+		translate(v=[-25,-30,0])
+			rotate(a=[0,90,0])
+				cylinder(h = 55, r=8, $fn=30);
+	}
 
+	// NEMA17 motor mount socket
+	translate(v=[-2.6, 0, 3.6])
+		cube(size = [47,43,11], center = true);
+	// NEMA17 motor mount screw holes
+	translate(v=[15,15,0])
+		cube(size = [9,3.2,25], center = true);
+	translate(v=[-15,15,0])
+		cube(size = [9,3.2,25], center = true);
+	translate(v=[15,-15,0])
+		cube(size = [9,3.2,25], center = true);
+	translate(v=[-15,-15,0])
+		cube(size = [9,3.2,25], center = true);
+	// NEMA17 motor mount shaft hole
+	translate(v=[0,0,-20])
+		cylinder(h = 100, r=15);
 
-translate(v=[0,7,0]) rotate(a=[0,90,0]) cylinder(h = 100, r=2.2);
-translate(v=[0,-7,0]) rotate(a=[0,90,0]) cylinder(h = 100, r=2.2);
-translate(v=[0,7,0]) rotate(a=[0,90,0]) rotate(a=[0,0,30]) cylinder(h = 24, r=4,$fn =6);
-translate(v=[0,-7,0]) rotate(a=[0,90,0]) rotate(a=[0,0,30]) cylinder(h = 24, r=4, $fn=6);
+	// top rod holes
+	translate(v=[-50,30,0])
+		rotate(a=[0,90,0])
+			cylinder(h = 100, r=4.5);
+	translate(v=[-50,-30,0])
+		rotate(a=[0,90,0])
+			cylinder(h = 100, r=4.5);
 
+	// Z bar socket
+		translate(v=[30,0,-20])
+			cylinder(h = 100, r=4.2);
+			
+	// Z bar clamp screw holes
+	translate(v=[0,7,0])
+		rotate(a=[0,90,0])
+			cylinder(h = 100, r=2.2);
+	translate(v=[0,-7,0])
+		rotate(a=[0,90,0])
+			cylinder(h = 100, r=2.2);
+
+	// Z bar clamp nut traps
+	translate(v=[0,7,0])
+		rotate(a=[0,90,0])
+			rotate(a=[0,0,30])
+				cylinder(h = 24, r=4,$fn =6);
+	translate(v=[0,-7,0])
+		rotate(a=[0,90,0])
+			rotate(a=[0,0,30])
+				cylinder(h = 24, r=4, $fn=6);
 }


### PR DESCRIPTION
hi.

thank you for the lovely redesign! I'm changing direction and going for prusa mendel now that I've found this!

When perusing the openscad models, I found them hard to read and understand, and the x-end-\* nut traps had skins across their bottoms. I tidied up some of the files, made them significantly easier to read, removed some redundant transforms and rotations, and fixed the skins in the nut traps.

ps: editing openscad files in an external editor with familiar keys and syntax highlighting and pressing f4 in openscad is much easier than using openscad's own text editor :)
