### PR TITLE
easier screwing of left x-carriage belt clamp

### DIFF
--- a/x-carriage.scad
+++ b/x-carriage.scad
@@ -34,8 +34,8 @@ translate(v = [0,0,2.5]) union(){difference(){
 		//Nut holder base - belt clamps
 		translate(v = [33-(7.5/2), -18, 1]) cube(size = [45-7.5,15,7], center = true);
 		translate(v = [33+45/2-7.5, -18, 1]) cylinder(h = 7, r=7.5, $fn=18, center=true);
-		translate(v = [33-(7.5/2), 18, 1]) cube(size = [45-7.5,15,7], center = true);
-		translate(v = [33+45/2-7.5, 18, 1]) cylinder(h = 7, r=7.5, $fn=18, center=true);
+		translate(v = [33-(7.5/2), 8, 1]) cube(size = [45-7.5,15,7], center = true);
+		translate(v = [33+45/2-7.5, 8, 1]) cylinder(h = 7, r=7.5, $fn=18, center=true);
 
 		//Bushing holder
 		translate(v = [-25, 30, 5])cube(size = [26,10,15], center = true);
@@ -88,10 +88,10 @@ translate(v = [0,0,2.5]) union(){difference(){
 	translate(v = [48, -18, 2]) cylinder(h = 10, r=m3_diameter/2, $fn=9, center=true);
 	translate(v = [48, -18, 5]) cylinder(h = 9, r=m3_nut_diameter/2, $fn=6, center=true);
 
-	translate(v = [30, 18, 2]) cylinder(h = 10, r=m3_diameter/2, $fn=9, center=true);
-	translate(v = [30, 18, 5]) cylinder(h = 9, r=m3_nut_diameter/2, $fn=6, center=true);
-	translate(v = [48, 18, 2]) cylinder(h = 10, r=m3_diameter/2, $fn=9, center=true);
-	translate(v = [48, 18, 5]) cylinder(h = 9, r=m3_nut_diameter/2, $fn=6, center=true);
+	translate(v = [30, 8, 2]) cylinder(h = 10, r=m3_diameter/2, $fn=9, center=true);
+	translate(v = [30, 8, 5]) cylinder(h = 9, r=m3_nut_diameter/2, $fn=6, center=true);
+	translate(v = [48, 8, 2]) cylinder(h = 10, r=m3_diameter/2, $fn=9, center=true);
+	translate(v = [48, 8, 5]) cylinder(h = 9, r=m3_nut_diameter/2, $fn=6, center=true);
 
 
 		translate(v = [-25, -20, 2.5]) rotate(a=[0,90,0]) cylinder(h = 30, r=m4_diameter/2, $fn=10, center=true);


### PR DESCRIPTION
Move left x-carriage belt clamp a bit to the right: screwing the belt is a lot easier if the screw is not below the motor.
