### PR TITLE
Fix Z motor mount position so motor sits centered vs mounts

### DIFF
--- a/bar-clamp.scad
+++ b/bar-clamp.scad
@@ -11,6 +11,7 @@
 include <configuration.scad>
 
 /**
+ * @id bar-clamp
  * @name Bar clamp
  * @category Printed
  * @using 2 m8nut

--- a/belt-clamp.scad
+++ b/belt-clamp.scad
@@ -10,6 +10,7 @@
 include <configuration.scad>
 
 /**
+ * @id belt-clamp
  * @name Belt clamp
  * @category Printed
  */ 

--- a/calibration.scad
+++ b/calibration.scad
@@ -9,7 +9,8 @@
 include <configuration.scad>
 
 /**
- *@name Configuration test
+ * @id calibration
+ * @name Configuration test
  */
 module configurationtest(){
 difference(){

--- a/coupling.scad
+++ b/coupling.scad
@@ -10,6 +10,7 @@
 include <configuration.scad>
 
 /**
+ * @id coupling
  * @name Coupling
  * @category Printed
  * @using 1 m3x25

--- a/endstop-holder.scad
+++ b/endstop-holder.scad
@@ -11,6 +11,7 @@
 include <configuration.scad>
 
 /**
+ * @id endstop-holder
  * @name Endstop holder
  * @category Printed
  * @using 1 m3x20

--- a/frame-vertex.scad
+++ b/frame-vertex.scad
@@ -35,6 +35,7 @@ module teardrop (r=8,h=20)
 vfvertex_height=m8_diameter+4.5;
 
 /**
+ * @id frame-vertex
  * @name Frame vertex
  * @category Printed
  * @link frame-vertex
@@ -42,6 +43,7 @@ vfvertex_height=m8_diameter+4.5;
  * @using 8 m8washer
  */
 /**
+ * @id frame-vertex-foot
  * @name Frame vertex with foot
  * @category Printed
  * @link frame-vertex-foot

--- a/pla-bushing.scad
+++ b/pla-bushing.scad
@@ -21,10 +21,10 @@
 include <configuration.scad>
 
 /**
+ * @id bushing
  * @name Bushing
  * @category Printed
- * @link bushing
- */ 
+ */
 
 rodsize = bushing_rodsize;
 outerDiameter = bushing_outerDiameter;

--- a/pulley.scad
+++ b/pulley.scad
@@ -5,6 +5,7 @@ include <configuration.scad>
 
 
 /**
+ * @id pulley
  * @name Pulley
  * @category Printed
  * @using 1 m3nut

--- a/reprap.tdoc
+++ b/reprap.tdoc
@@ -23,7 +23,7 @@
  * @using 4 frame-vertex-foot
  * @using 2 frame-vertex
  * @using 8 bar-clamp
- * @link frame
+ * @id frame
  */
   
 /**
@@ -32,54 +32,54 @@
  * @common
  * @name M8 nut
  * @category Nuts&bolts
- * @link m8nut
+ * @id m8nut
  */
  
 /**
  * @name M8 washer
  * @common
  * @category Nuts&bolts
- * @link m8washer
+ * @id m8washer
  */
 
 /**
  * @name M8 spring
  * @common
  * @category Nuts&bolts
- * @link m8spring
+ * @id m8spring
  */
 
 /**
  * @name M3 nut
  * @common
  * @category Nuts&bolts
- * @link m3nut
+ * @id m3nut
  */
  
 /**
  * @name M3 washer
  * @common
  * @category Nuts&bolts
- * @link m3washer
+ * @id m3washer
  */
 
 /**
  * @name M3 10mm screw
  * @common
  * @category Nuts&bolts
- * @link m3x10
+ * @id m3x10
  */
  
 /**
  * @name M3 20mm screw
  * @common
  * @category Nuts&bolts
- * @link m3x20
+ * @id m3x20
  */
  
 /**
  * @name M3 25mm screw
  * @common
  * @category Nuts&bolts
- * @link m3x25
+ * @id m3x25
  */

--- a/rod-clamp.scad
+++ b/rod-clamp.scad
@@ -11,9 +11,10 @@
 include <configuration.scad>
 
 /**
+ * @id rod-clamp
  * @name Rod clamp
  * @category Printed
- */  
+ */
 
 module rodclamp(){ 
 translate([0,0,5]) difference(){

--- a/x-carriage.scad
+++ b/x-carriage.scad
@@ -12,6 +12,7 @@ include <configuration.scad>
 
 /**
  * Slides on the x-axis with extruder.
+ * @id x-carriage
  * @name X carriage
  * @category Printed
  * @using 4 m3x10

--- a/x-end-idler.scad
+++ b/x-end-idler.scad
@@ -11,6 +11,7 @@ include <configuration.scad>
 corection = 1.17; 
 
 /**
+ * @id x-end-idler
  * @name X end idler
  * @category Printed
  * @using 2 bushing

--- a/x-end-motor.scad
+++ b/x-end-motor.scad
@@ -11,6 +11,7 @@ include <configuration.scad>
 corection = 1.17; 
 
 /**
+ * @id x-end-motor
  * @name X end motor
  * @category Printed
  * @using 2 bushing
@@ -19,7 +20,7 @@ corection = 1.17;
  * @using 4 m3washer
  * @using 1 m8spring
  * @using 2 m8nut
- */  
+ */
 
 
 module xendmotor(){

--- a/ybrac-t.scad
+++ b/ybrac-t.scad
@@ -10,12 +10,13 @@
 include <configuration.scad>
 
 /**
+ * @id y-motor-bracket
  * @name Y motor bracket
  * @link y-motor-bracket
  * @category Printed
  * @using 3 m3washer
  * @using 3 m3x10
- */ 
+ */
 
 module ybract(){
 difference(){

--- a/z-motor-mount.scad
+++ b/z-motor-mount.scad
@@ -31,11 +31,13 @@ translate(v=[-25,-29.25,0]) rotate(a=[0,90,0]) cylinder(h = 55, r=8, $fn=30);
 translate(v=[-2.1,0,3.1]) cube(size = [46,43,10], center = true);
 
 // Nema 17
+translate(v=[-1,0,0]) {
 rotate ([0,0,45]) translate([20,0,0]) cube(size = [9,3.2,25], center = true);
 rotate ([0,0,-45]) translate([20,0,0]) cube(size = [9,3.2,25], center = true);
 rotate ([0,0,135]) translate([20,0,0]) cube(size = [9,3.2,25], center = true);
 rotate ([0,0,-135]) translate([20,0,0]) cube(size = [9,3.2,25], center = true);
 translate(v=[0,0,-10])cylinder(h = 20, r=13);
+}
 
 translate(v=[30,0,-10]) cylinder(h = 20, r=4.2);
 translate(v=[-26,29.25,0]) rotate(a=[0,90,0]) cylinder(h = 58, r=m8_diameter/2);

--- a/z-motor-mount.scad
+++ b/z-motor-mount.scad
@@ -10,6 +10,7 @@
 include <configuration.scad>
 
 /**
+ * @id z-motor-mount
  * @name Z motor mount
  * @category Printed
  * @using 2 m3x25

--- a/z-motor-mount.scad
+++ b/z-motor-mount.scad
@@ -2,7 +2,7 @@
 // Z motor mount
 // Used for mounting Z motors
 // GNU GPL v2
-// Josef Průša
+// Josef Prusa
 // josefprusa@me.com
 // prusadjs.cz
 // http://www.reprap.org/wiki/Prusa_Mendel
@@ -21,34 +21,44 @@ include <configuration.scad>
  */
  
 module zmotormount(){
-difference(){
-union(){
-translate(v=[2.5,0,0]) cube(size = [55,60,16], center = true);
-translate(v=[2.5,0,-4]) cube(size = [55,74.5,8], center = true);
-translate(v=[-25,29.25,0]) rotate(a=[0,90,0]) cylinder(h = 55, r=8, $fn=30);
-translate(v=[-25,-29.25,0]) rotate(a=[0,90,0]) cylinder(h = 55, r=8, $fn=30);
-}
-translate(v=[-2.1,0,3.1]) cube(size = [46,43,10], center = true);
-
-// Nema 17
-translate(v=[-1,0,0]) {
-rotate ([0,0,45]) translate([20,0,0]) cube(size = [9,3.2,25], center = true);
-rotate ([0,0,-45]) translate([20,0,0]) cube(size = [9,3.2,25], center = true);
-rotate ([0,0,135]) translate([20,0,0]) cube(size = [9,3.2,25], center = true);
-rotate ([0,0,-135]) translate([20,0,0]) cube(size = [9,3.2,25], center = true);
-translate(v=[0,0,-10])cylinder(h = 20, r=13);
-}
-
-translate(v=[30,0,-10]) cylinder(h = 20, r=4.2);
-translate(v=[-26,29.25,0]) rotate(a=[0,90,0]) cylinder(h = 58, r=m8_diameter/2);
-translate(v=[-26,-29.25,0]) rotate(a=[0,90,0]) cylinder(h = 58, r=m8_diameter/2);
-
-
-translate(v=[16,7,0]) rotate(a=[0,90,0]) cylinder(h = 15, r=m3_diameter/2);
-translate(v=[16,-7,0]) rotate(a=[0,90,0]) cylinder(h = 15, r=m3_diameter/2);
-translate(v=[0,7,0]) rotate(a=[0,90,0]) rotate(a=[0,0,30]) cylinder(h = 24, r=m3_nut_diameter/2,$fn =6);
-translate(v=[0,-7,0]) rotate(a=[0,90,0]) rotate(a=[0,0,30]) cylinder(h = 24, r=m3_nut_diameter/2, $fn=6);
-
-}
+	difference(){
+		// Body
+		union(){
+			translate(v=[2.5,0,-0.5]) cube(size = [55,60,17], center = true);
+			translate(v=[2.5,0,-4.5]) cube(size = [55,74.5,9], center = true);
+			translate(v=[-25,29.25,0]) rotate(a=[0,90,0]) cylinder(h = 55, r=8, $fn=30);
+			translate(v=[-25,-29.25,0]) rotate(a=[0,90,0]) cylinder(h = 55, r=8, $fn=30);
+		}
+		
+		// Motor well
+		translate(v=[-2.1,0,3.1]) cube(size = [46,43,10], center = true);
+		
+		// Nema 17
+		translate(v=[-1,0,0]) {
+			rotate ([0,0,45]) translate([20,0,0]) cube(size = [9,3.2,25], center = true);
+			rotate ([0,0,-45]) translate([20,0,0]) cube(size = [9,3.2,25], center = true);
+			rotate ([0,0,135]) translate([20,0,0]) cube(size = [9,3.2,25], center = true);
+			rotate ([0,0,-135]) translate([20,0,0]) cube(size = [9,3.2,25], center = true);
+			translate(v=[0,0,-10]) cylinder(h = 20, r=11.5);
+			translate(v=[0,13,-10]) cylinder(h = 20, r=2.2);
+			translate(v=[0,-13,-10]) cylinder(h = 20, r=2.2);
+			translate(v=[13,0,-10]) cylinder(h = 20, r=2.2);
+			translate(v=[-13,0,-10]) cylinder(h = 20, r=2.2);
+		}
+		
+		// Z smooth rod
+		translate(v=[30,0,-10]) cylinder(h = 20, r=4.2);
+		
+		// threaded rods
+		translate(v=[-26,29.25,0]) rotate(a=[0,90,0]) cylinder(h = 58, r=m8_diameter/2);
+		translate(v=[-26,-29.25,0]) rotate(a=[0,90,0]) cylinder(h = 58, r=m8_diameter/2);
+		
+		// Z rod clamps
+		translate(v=[16,7,0]) rotate(a=[0,90,0]) cylinder(h = 15, r=m3_diameter/2);
+		translate(v=[16,-7,0]) rotate(a=[0,90,0]) cylinder(h = 15, r=m3_diameter/2);
+		// Nut traps
+		translate(v=[0,7,0]) rotate(a=[0,90,0]) rotate(a=[0,0,90]) cylinder(h = 24, r=m3_nut_diameter/2,$fn=6);
+		translate(v=[0,-7,0]) rotate(a=[0,90,0]) rotate(a=[0,0,90]) cylinder(h = 24, r=m3_nut_diameter/2, $fn=6);
+	}
 }
 zmotormount();


### PR DESCRIPTION
I found that my motors don't sit centered in the mounts- the mounting holes are ~1mm too close to the Z rod clamp. First commit fixes this.

Second commit shrinks the flange hole slightly (motor still fits) and adds some M3 screw holes so I can mount a 608 bearing instead of a motor. It shouldn't compromise the bracket or alter its existing function in any way that I can imagine, while providing a potential upgrade path for those of us who have 4 motors and can't get a 5th just yet.
