### PR TITLE
Felt - adding acme leadscrew support for Z axis.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,13 @@
-target metric: OPENSCAD:=$(shell which openscad) -D variant=0 -D linear=0
+target metric: OPENSCAD:=$(shell which openscad) -D variant=0 -D linear=0 -D acme=0
 target metric: TARGET=./metric-prusa
 target metric-lm8uu: TARGET=./metric-prusa-linear
-target metric-lm8uu: OPENSCAD:=$(shell which openscad) -D variant=0 -D linear=1
+target metric-lm8uu: OPENSCAD:=$(shell which openscad) -D variant=0 -D linear=1 -D acme=0
+target metric-lm8uu-acme: TARGET=./metric-prusa-linear-acme
+target metric-lm8uu-acme: OPENSCAD:=$(shell which openscad) -D variant=0 -D linear=1 -D acme=1
 target sae: TARGET=./sae-prusa
-target sae: OPENSCAD:=$(shell which openscad) -D variant=1 -D linear=0
+target sae: OPENSCAD:=$(shell which openscad) -D variant=1 -D linear=0 -D acme=0
 target sae-lm8uu: TARGET=./sae-prusa-linear
-target sae-lm8uu: OPENSCAD:=$(shell which openscad) -D variant=1 -D linear=1
+target sae-lm8uu: OPENSCAD:=$(shell which openscad) -D variant=1 -D linear=1 -D acme=0
 
 PARTS= $(TARGET)/x-end-motor.stl $(TARGET)/x-end-idler.stl $(TARGET)/bar-clamp.stl
 
@@ -14,6 +16,7 @@ help:
 	@echo Options:
 	@echo make metric: makes metric parts
 	@echo make metric-lm8uu: makes metric parts
+	@echo make metric-lm8uu-acme: makes metric parts with acme leadscrew
 	@echo make sae: makes metric parts
 	@echo make sae-lm8uu: makes metric parts
 	@echo make clean: deletes the stl directory with the output files
@@ -21,6 +24,7 @@ help:
 	@echo SAE parts get saved in ./stl-sae, metric parts in ./stl
 metric : parts
 metric-lm8uu : parts
+metric-lm8uu-acme : parts
 sae : parts
 sae-lm8uu : parts
 parts : $(TARGET) $(TARGETS)

--- a/source/configuration.scad
+++ b/source/configuration.scad
@@ -27,6 +27,8 @@ thin_wall = 3;
 
 // LM8UU
 linear =0;
+// ACME leadscrew
+acme =0;
 
 
 // CHANGE ONLY THE STUFF YOU KNOW

--- a/source/metric.scad
+++ b/source/metric.scad
@@ -21,6 +21,9 @@ smooth_bar_diameter_horizontal = 8.5;
 m8_diameter = 9;
 m8_nut_diameter = 16.4;
 
+acme_diameter = 11;
+acme_nut_diameter = 20;
+
 m4_diameter = 4.5;
 m4_nut_diameter = 9;
 
@@ -35,3 +38,4 @@ bushing_material_thickness = 1;
 // Motors
 
 motor_shaft = 5.5;
+

--- a/source/x-end-idler.scad
+++ b/source/x-end-idler.scad
@@ -27,7 +27,8 @@ module xendidler(){
 		mirror(){
 			difference(){
 				union(){
-					translate(v = [21, -21.5, 25.3]) cube(size = [25.5,7,4.4], center = true);
+					if (acme==0) translate(v = [21, -21.5, 25.3]) cube(size = [25.5,7,4.4], center = true);
+					if (acme==1) translate(v = [21, -21.5, 25.3]) cube(size = [20.5,7,4.4], center = true);
 					translate(v = [21, 12.5, 25.3]) #cube(size = [24,5,4.4], center = true);
 					translate(v = [32.5, -5, 7.5]) cube(size = [5,40,40], center = true);
 				}

--- a/source/x-end.scad
+++ b/source/x-end.scad
@@ -144,8 +144,8 @@ difference()
 
 
 			//Nut Trap
-			translate([0,-20,0]) //
-			cylinder(h=40,r=m8_nut_diameter/2+thin_wall*corection,$fn=6);
+			if (acme==0) translate([0,-20,0]) cylinder(h=40,r=m8_nut_diameter/2+thin_wall*corection,$fn=6);
+			if (acme==1) translate([0,-20,0]) cylinder(h=40,r=acme_nut_diameter/2+thin_wall*corection,$fn=6);
 		}
 
 		// Slider cutout.
@@ -155,13 +155,13 @@ difference()
 		//Rod hole.
 		difference()
 		{
-			translate([0,-20,39.5]) 
-			cylinder(h=90,r=m8_nut_diameter/2,$fn=6,center=true);
-			translate([0,-20,8.5]) 
-			cylinder(h=4,r=m8_nut_diameter/2+thin_wall,$fn=6,center=true);
+			if (acme==0) translate([0,-20,39.5]) cylinder(h=90,r=m8_nut_diameter/2,$fn=6,center=true); 
+			if (acme==1) translate([0,-20,39.5]) cylinder(h=90,r=acme_nut_diameter/2,$fn=6,center=true);
+			if (acme==0) translate([0,-20,8.5]) cylinder(h=4,r=m8_nut_diameter/2+thin_wall,$fn=6,center=true);
+			if (acme==1) translate([0,-20,8.5]) cylinder(h=4,r=acme_nut_diameter/2+thin_wall,$fn=6,center=true);
 		}
-		translate([0,-20,52]) 
-		cylinder(h=90,r=m8_diameter/2,$fn=9,center=true);
+		if (acme==0) translate([0,-20,52]) cylinder(h=90,r=m8_diameter/2,$fn=9,center=true);
+		if (acme==1) translate([0,-20,52]) cylinder(h=90,r=acme_diameter/2,$fn=9,center=true);
 	}
 }
 


### PR DESCRIPTION
I've only applied the changes to metric-lm8uu target.  I can't really test the build mechanism because the -D define functionality doesn't work for me (linux, OpenSCAD version 2011.06.14).

A) Is this support you want upstream?
B) Do you want me to apply the -D acme target to your other combinations? ie, sae-lm8uu-acme etc...
