### PR TITLE
M3 nut diameter incorrect

### DIFF
--- a/source/metric.scad
+++ b/source/metric.scad
@@ -25,7 +25,7 @@ m4_diameter = 4.5;
 m4_nut_diameter = 9;
 
 m3_diameter = 3.6;
-m3_nut_diameter = 5.3;
+m3_nut_diameter = 5.5;
 m3_nut_diameter_horizontal = 6.1;
 
 // Bushing holder


### PR DESCRIPTION
The M3 nut diameter should be 5.5 according to McMaster: http://imgur.com/549cO

It looks like 5.5mm is the max allowable M3 nut size and 5.38 is the smallest (source: http://www.roymech.co.uk/Useful_Tables/Screws/Hex_Screws.htm)
