### PR TITLE
Fixed a bug with the screw_hole_spacing parameter on sanguinololu-holder

### DIFF
--- a/source/sanguinololu-holder.scad
+++ b/source/sanguinololu-holder.scad
@@ -33,7 +33,7 @@ difference(){
 		translate([-4-3, -3, 0]) cube([6,5,10]);
 		translate([-4-3-screw_hole_spacing, -3, 0]) cube([6,5,10]);
 		
-		translate([-27-25, 0, 0]) cube([35+40, 4, 10]);
+		translate([-9-screw_hole_spacing, 0, 0]) cube([32+screw_hole_spacing, 4, 10]);
 		translate([17, 17.5, 5]) rotate([90, 0, 0]) #cylinder(h =5, r = 5.77, $fn = 6);
 		
 		


### PR DESCRIPTION
Enlarging the screw-hole spacing didn't enlarge the bar itself.
